### PR TITLE
added option via #define to swap alt and gui key actions

### DIFF
--- a/adb_to_usb.ino
+++ b/adb_to_usb.ino
@@ -1,6 +1,7 @@
 #include "adb.h"
 #include "keymap.h"
-#define LOCKING_CAPS // comment this out if not using a keyboard with locking Caps Lock
+// #define LOCKING_CAPS // comment this out if not using a keyboard with locking Caps Lock
+// #define SWAP_ALT_GUI // uncomment this if you want to swap the alt and super(GUI) keys to emulate behavior/positioning of windows key
 
 static bool has_media_keys = false;
 static bool is_iso_layout = false;
@@ -14,16 +15,27 @@ static void register_key(uint8_t key)
 {
     uint8_t tmp[6];
     if (key&0x80) {
+        // handles key press
         //matrix[row] &= ~(1<<col);
         switch (key & 0x7F) {
           case 0x36: // LCTRL
             buf[0] &= ~(1<<0); break;
           case 0x37: // LGUI
-            buf[0] &= ~(1<<3); break;
+#ifdef SWAP_ALT_GUI
+            buf[0] &= ~(1<<2); // LALT
+#else
+            buf[0] &= ~(1<<3); // LGUI
+#endif
+            break;
           case 0x38: // LSHIFT
             buf[0] &= ~(1<<1); break;
           case 0x3A: // LALT
-            buf[0] &= ~(1<<2); break;
+#ifdef SWAP_ALT_GUI
+            buf[0] &= ~(1<<3); // LGUI
+#else
+            buf[0] &= ~(1<<2); // LALT
+#endif
+            break;
           case 0x7B: // RSHIFT
             buf[0] &= ~(1<<5); break;
           case 0x7C: // RALT
@@ -54,15 +66,26 @@ static void register_key(uint8_t key)
 #ifdef LOCKING_CAPS
         if (key == 57 && capsOn) return;
 #endif
+        // handles key releases
         switch (key) {
           case 0x36: // LCTRL
             buf[0] |= (1<<0); break;
           case 0x37: // LGUI
-            buf[0] |= (1<<3); break;
+#ifdef SWAP_ALT_GUI
+            buf[0] |= (1<<2); // LALT
+#else 
+            buf[0] |= (1<<3); // LGUI
+#endif
+             break;
           case 0x38: // LSHIFT
             buf[0] |= (1<<1); break;
           case 0x3A: // LALT
-            buf[0] |= (1<<2); break;
+#ifdef SWAP_ALT_GUI
+            buf[0] |= (1<<3); // LGUI
+#else 
+            buf[0] |= (1<<2); // LALT
+#endif
+            break;
           case 0x7B: // RSHIFT
             buf[0] |= (1<<5); break;
           case 0x7C: // RALT

--- a/adb_to_usb.ino
+++ b/adb_to_usb.ino
@@ -1,6 +1,6 @@
 #include "adb.h"
 #include "keymap.h"
-// #define LOCKING_CAPS // comment this out if not using a keyboard with locking Caps Lock
+#define LOCKING_CAPS // comment this out if not using a keyboard with locking Caps Lock
 // #define SWAP_ALT_GUI // uncomment this if you want to swap the alt and super(GUI) keys to emulate behavior/positioning of windows key
 
 static bool has_media_keys = false;


### PR DESCRIPTION
Added option to swap windows/gui/super (whatever it is called) key with the alt key behaviour in order to match that of a keyboard with traditional windows/GUI key placement. Helpful for users used to such a layout. 